### PR TITLE
Feat/Add font settings and toolbars

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import Settings from './pages/Settings/Settings';
 import Pages from './pages/Detail/Pages';
 import About from './pages/Settings/About';
 import Data from './pages/Settings/Data';
+import Font from './pages/Settings/Font';
 
 /* Core CSS required for Ionic components to work properly */
 import '@ionic/react/css/core.css';
@@ -40,6 +41,8 @@ import { useTranslation } from 'react-i18next';
 import { StatusBar } from '@capacitor/status-bar';
 import "./lib/Darkmode";
 import { getUserThemePreference } from './lib/Darkmode';
+
+import "./imode.css";
 
 const getConfig = () => {
   let config:any = {
@@ -124,6 +127,9 @@ function App() {
             </Route>
             <Route exact path="/about">
               <About />
+            </Route>
+            <Route exact path="/font">
+              <Font />
             </Route>
             {/* dynamic */}
             <Route path="/read/:view/:id" component={Pages} />

--- a/src/components/Button/DeleteAllData.tsx
+++ b/src/components/Button/DeleteAllData.tsx
@@ -48,6 +48,7 @@ export default function DeleteAllData() {
     })
     await Preferences.remove({ key: key.read });
     await Preferences.remove({ key: key.settings });
+    await Preferences.remove({ key: key.viewer });
     trigger("weread:listChange")
   };
   return (

--- a/src/components/Button/DeleteArticle.tsx
+++ b/src/components/Button/DeleteArticle.tsx
@@ -24,6 +24,18 @@ export default function DeleteArticle({id}:{id:string}) {
       directory: Directory.Data,
       recursive: true
     })
+    
+    // Remove viewer settings for this article
+    const viewerData = await Preferences.get({ key: key.viewer });
+    if (viewerData.value) {
+      let viewerSettings = JSON.parse(viewerData.value);
+      delete viewerSettings[id];
+      await Preferences.set({
+        key: key.viewer,
+        value: JSON.stringify(viewerSettings),
+      });
+    }
+    
     let content = JSON.stringify(readData);
     await Preferences.set({
       key: key.read,

--- a/src/components/Button/ExportData.tsx
+++ b/src/components/Button/ExportData.tsx
@@ -57,10 +57,12 @@ export default function ExportData() {
       // Get preferences data
       const readData = await Preferences.get({ key: key.read });
       const settingsData = await Preferences.get({ key: key.settings });
+      const viewerData = await Preferences.get({ key: key.viewer });
       
       const preferencesData = {
         read: readData.value ? JSON.parse(readData.value) : [],
         settings: settingsData.value ? JSON.parse(settingsData.value) : {},
+        viewer: viewerData.value ? JSON.parse(viewerData.value) : {},
       };
       
       // Save preferences to temp directory

--- a/src/components/Button/ImportData.tsx
+++ b/src/components/Button/ImportData.tsx
@@ -256,6 +256,14 @@ export default function ImportData() {
         value: JSON.stringify(mergedSettings),
       });
 
+      // Restore viewer settings if available
+      if (importedPreferences.viewer) {
+        await Preferences.set({
+          key: key.viewer,
+          value: JSON.stringify(importedPreferences.viewer),
+        });
+      }
+
       setProgress(1);
 
       // Clean up extraction directory

--- a/src/components/Button/UrlOpenConfirm.tsx
+++ b/src/components/Button/UrlOpenConfirm.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from "react-i18next";
 import { globeSharp } from "ionicons/icons";
 import { Clipboard } from "@capacitor/clipboard";
 
-import "./UrlOpenConfirm.css";
 import { useContext } from "react";
 import { SettingsContext } from "../../SettingsContext";
 import { truncateURI } from "../../lib/utils";

--- a/src/components/Read/Horizontal.tsx
+++ b/src/components/Read/Horizontal.tsx
@@ -1,17 +1,21 @@
-import { useContext, useEffect, useState } from "react"
+import { useContext, useEffect, useRef, useState } from "react"
 import { DetailContext } from "../../pages/Detail/Context"
 import { useSwipeable } from "react-swipeable"
-import { IonRange } from "@ionic/react"
 import { useTranslation } from "react-i18next"
 import HtmlContent from "./HtmlContent"
+import { SettingsContext } from "../../SettingsContext"
+import ReadingToolbars from "./ReadingToolbars"
+import { useViewerContext } from "../../contexts/ViewerContext"
 
 export default function Horizontal() {
   const article = useContext<any>(DetailContext)
+  const settings = useContext(SettingsContext)
   const {t} = useTranslation()
   const [somethingInDivClicked,setSomethingInDivClicked] = useState(false)
   const [controlShow, setControlShow] = useState(false)
   const [allPage,setAllPage] = useState(1)
   const [page,setPage] = useState(1)
+  const { fontSize, saveFontSize } = useViewerContext()
   const updateAllPage = () => {
     if (document.getElementById("horizontal_readin") !== null){
       if (document.getElementById("horizontal_readin")?.offsetWidth !== null){
@@ -19,6 +23,9 @@ export default function Horizontal() {
         console.log("allpage: " +newAllPage)
         if (isNaN(newAllPage)) return
         setAllPage(newAllPage)
+        if (page > newAllPage) {
+          setPage(newAllPage);
+        }
       }
     }
   }
@@ -78,29 +85,33 @@ export default function Horizontal() {
     updateAllPage()
     setPage(1)
   },[article.html])
+
+  useEffect(() => {
+    updateAllPage();
+  }, [fontSize]);
+
   return (
     <div style={{paddingTop: "var(--ion-safe-area-top, 0)", paddingBottom: "var(--ion-safe-area-bottom, 0)", width: "100%", height: "100%"}}>
-      <div style={{position:"fixed",left: article.columnGap + "px"}}>
-        <span>{page} / {allPage}</span>
-      </div>
+      <ReadingToolbars
+        controlShow={controlShow}
+        fontSize={fontSize}
+        page={page}
+        allPage={allPage}
+        triggerId="font-settings-trigger-horizontal"
+        onFontSizeChange={saveFontSize}
+        onPageChange={(newPage) => {
+          setPage(newPage);
+          turnToPage(newPage);
+        }}
+      />
+
       <div id="horizontal_container" style={{width: "100%", height: "100%", display: "flex", flexDirection: "column"}} {...handlers} onClick={(e) => handleDivClicked(e)}>
           <div id="horizontal_readout" style={{position:"relative",overflowX: "hidden", flex: 1}}>
             <div id="horizontal_readin" style={{touchAction: "none", position: "absolute", overflowX: "scroll", height: "100%", columnWidth: "500px",columnGap: article.columnGap*2+"px",paddingLeft: article.columnGap+"px",paddingRight: article.columnGap+"px",paddingTop:"20px",paddingBottom: "20px"}} >
-              <HtmlContent type="horizontal" setSomethingInDivClicked={setSomethingInDivClicked} />
+              <HtmlContent type="horizontal" setSomethingInDivClicked={setSomethingInDivClicked} fontSize={fontSize} />
             </div>
           </div>
       </div>
-      {
-        false ?
-      <div style={{position:"fixed", bottom: "0px", width:"100%", minHeight: "150px", backgroundColor: "var(--background)", borderTop: "1px solid var(--ion-color-light-contrast)"}}>
-        <div style={{padding: "15px"}}>
-          <IonRange labelPlacement="start" ticks={true} snaps={true} min={0} max={3} onIonChange={({ detail }) => console.log(detail.value)}>
-            <div slot="label">{t("pages.detail.control.spaceBetweenPages")}</div>
-          </IonRange>
-        </div>
-      </div>
-        : <></>
-      }
     </div>
   )
 }

--- a/src/components/Read/HtmlContent.tsx
+++ b/src/components/Read/HtmlContent.tsx
@@ -13,9 +13,11 @@ import { truncateURI } from "../../lib/utils";
 export default function HtmlContent({
   setSomethingInDivClicked,
   type,
+  fontSize,
 }: {
   setSomethingInDivClicked?: any;
   type: "normal" | "vertical" | "horizontal";
+  fontSize?: number;
 }) {
   if (!setSomethingInDivClicked) {
     setSomethingInDivClicked = (e) => console.log(e);
@@ -126,11 +128,15 @@ export default function HtmlContent({
         e.removeAttribute('height');
       }
       e.onclick = () => {
+        setSomethingInDivClicked(true);
         viewer({
           urls: [e.src],
           zIndex: 9999,
           doubleTap: true,
         });
+        setTimeout(() => {
+          setSomethingInDivClicked(false)
+        }, 100)
       };
     });
   };
@@ -139,11 +145,43 @@ export default function HtmlContent({
     updateImgTag();
   }, [article.html]);
   return (
-    <div
-      id={"htmlContent_" + article.id + "_" + type}
-      className="html"
-      key={article.id}
-      dangerouslySetInnerHTML={{ __html: article.html }}
-    />
+    <>
+      {fontSize && (
+        <style>
+          {`
+            #htmlContent_${article.id}_${type} {
+              font-size: ${fontSize}px;
+            }
+            #htmlContent_${article.id}_${type} p {
+              font-size: ${fontSize}px;
+            }
+            #htmlContent_${article.id}_${type} h1 {
+              font-size: ${fontSize * 2}px;
+            }
+            #htmlContent_${article.id}_${type} h2 {
+              font-size: ${fontSize * 1.5}px;
+            }
+            #htmlContent_${article.id}_${type} h3 {
+              font-size: ${fontSize * 1.3}px;
+            }
+            #htmlContent_${article.id}_${type} h4 {
+              font-size: ${fontSize * 1.1}px;
+            }
+            #htmlContent_${article.id}_${type} h5 {
+              font-size: ${fontSize}px;
+            }
+            #htmlContent_${article.id}_${type} h6 {
+              font-size: ${fontSize * 0.9}px;
+            }
+          `}
+        </style>
+      )}
+      <div
+        id={"htmlContent_" + article.id + "_" + type}
+        className="html"
+        key={article.id}
+        dangerouslySetInnerHTML={{ __html: article.html }}
+      />
+    </>
   );
 }

--- a/src/components/Read/Normal.tsx
+++ b/src/components/Read/Normal.tsx
@@ -1,4 +1,4 @@
-import { useContext } from "react"
+import { useContext, useEffect } from "react"
 import { DetailContext } from "../../pages/Detail/Context"
 import { IonButton, IonIcon, useIonAlert } from "@ionic/react"
 import { pencilSharp, swapHorizontalSharp, swapVerticalSharp, volumeHighSharp, stopCircleSharp } from "ionicons/icons"
@@ -8,6 +8,8 @@ import HtmlContent from "./HtmlContent"
 import { SettingsContext } from "../../SettingsContext"
 import { useTts } from "./useTts"
 import { useTranslation } from "react-i18next"
+import ReadingSettingsButton from "./ReadingSettingsButton"
+import { useViewerContext } from "../../contexts/ViewerContext"
 
 export default function Normal() {
   const globalSettings = useContext(SettingsContext)
@@ -15,6 +17,7 @@ export default function Normal() {
   const history = useHistory()
   const { t } = useTranslation()
   const [presentAlert] = useIonAlert()
+  const { fontSize, saveFontSize, loadFontSize } = useViewerContext()
 
   const { isTtsActive, startTts, stopTts } = useTts((error) => {
     presentAlert({
@@ -67,8 +70,13 @@ export default function Normal() {
             <IonIcon slot="icon-only" icon={pencilSharp}></IonIcon>
           </IonButton>
           <UrlOpenConfirm url={article.url} />
+          <ReadingSettingsButton 
+            fontSize={fontSize}
+            triggerId="font-settings-trigger-normal"
+            onFontSizeChange={saveFontSize}
+          />
         </div>
-        <HtmlContent type="normal" />
+        <HtmlContent type="normal" fontSize={fontSize} />
       </div>
     </>
   )

--- a/src/components/Read/ReadingSettingsButton.tsx
+++ b/src/components/Read/ReadingSettingsButton.tsx
@@ -1,0 +1,59 @@
+import { IonButton, IonIcon, IonPopover, IonRange } from "@ionic/react"
+import { add, remove, settingsOutline } from "ionicons/icons"
+import { useTranslation } from "react-i18next"
+import { SettingsContext } from "../../SettingsContext"
+import { useContext } from "react"
+
+interface ReadingSettingsButtonProps {
+  fontSize: number
+  triggerId: string
+  onFontSizeChange: (newSize: number) => void
+}
+
+export default function ReadingSettingsButton({
+  fontSize,
+  triggerId,
+  onFontSizeChange
+}: ReadingSettingsButtonProps) {
+  const { t } = useTranslation()
+  const globalSettings = useContext(SettingsContext);
+
+  const adjustFontSize = (delta: number) => {
+    const newSize = Math.max(12, Math.min(48, fontSize + delta))
+    onFontSizeChange(newSize)
+  }
+
+  return (
+    <>
+      <IonButton id={triggerId} color="dark" fill="clear">
+        <IonIcon slot="icon-only" icon={settingsOutline} />
+      </IonButton>
+      
+      {/* Font Settings Popover */}
+      <IonPopover trigger={triggerId} triggerAction="click" dismissOnSelect={false} className={`${globalSettings.imode ? "nodrop" : ""}`}>
+        <div style={{ margin: "15px" }}>
+          <h4 style={{ margin: "0 0 15px 0" }}>{t("pages.detail.toolbar.fontSize")}</h4>
+          <div style={{ display: "flex", alignItems: "center", gap: "10px" }}>
+            <IonButton onClick={() => adjustFontSize(-1)} size="small" fill="clear">
+              <IonIcon icon={remove} />
+            </IonButton>
+            <IonRange
+              min={12}
+              max={48}
+              value={fontSize}
+              pin={true}
+              onIonChange={(e) => onFontSizeChange(e.detail.value as number)}
+              style={{ flex: 1 }}
+            />
+            <IonButton onClick={() => adjustFontSize(1)} size="small" fill="clear">
+              <IonIcon icon={add} />
+            </IonButton>
+          </div>
+          <div style={{ textAlign: "center", marginTop: "10px", fontSize: "16px", color: "var(--ion-color-medium)" }}>
+            {fontSize}px
+          </div>
+        </div>
+      </IonPopover>
+    </>
+  )
+}

--- a/src/components/Read/ReadingToolbars.tsx
+++ b/src/components/Read/ReadingToolbars.tsx
@@ -1,0 +1,82 @@
+import { IonBackButton, IonButtons, IonRange, IonToolbar } from "@ionic/react"
+import { useTranslation } from "react-i18next"
+import ReadingSettingsButton from "./ReadingSettingsButton"
+
+interface ReadingToolbarsProps {
+  controlShow: boolean
+  fontSize: number
+  page: number
+  allPage: number
+  triggerId: string
+  onFontSizeChange: (newSize: number) => void
+  onPageChange: (newPage: number) => void
+  toolbarPosition?: 'fixed' | 'relative'
+  direction?: 'ltr' | 'rtl'
+}
+
+export default function ReadingToolbars({
+  controlShow,
+  fontSize,
+  page,
+  allPage,
+  triggerId,
+  onFontSizeChange,
+  onPageChange,
+  toolbarPosition = 'fixed',
+  direction = 'ltr'
+}: ReadingToolbarsProps) {
+  const { t } = useTranslation()
+
+  const topToolbarStyle = toolbarPosition === 'fixed' 
+    ? { position: 'fixed' as const, top: 'calc(var(--ion-safe-area-top, 10px) + 5px)', left: '0', right: '0', zIndex: 1000 }
+    : {}
+
+  const bottomToolbarStyle = toolbarPosition === 'fixed'
+    ? { position: 'fixed' as const, bottom: 'calc(var(--ion-safe-area-bottom, 10px) + 5px)', left: '0', right: '0', zIndex: 1000 }
+    : {}
+
+  const bottomToolbarPadding = toolbarPosition === 'fixed'
+    ? { padding: '5px 40px 40px 20px' }
+    : { padding: '0 15px' }
+
+  return (
+    <>
+      {/* Top Toolbar */}
+      {controlShow && (
+        <>
+        <IonToolbar style={topToolbarStyle}>
+          <IonButtons slot="start">
+            <IonBackButton defaultHref="/home" text={t("app.navigate.back")}></IonBackButton>
+          </IonButtons>
+          <IonButtons slot="end">
+            <ReadingSettingsButton 
+              fontSize={fontSize}
+              triggerId={triggerId}
+              onFontSizeChange={onFontSizeChange}
+            />
+          </IonButtons>
+        </IonToolbar>
+        </>
+      )}
+
+      {/* Bottom Toolbar */}
+      {controlShow && (
+        <IonToolbar style={bottomToolbarStyle}>
+          <div style={{ display: "flex", alignItems: "center", ...bottomToolbarPadding }}>
+            <span style={{ marginRight: "10px", fontSize: "14px", minWidth: "80px" }}>{page} / {allPage}</span>
+            <IonRange
+              min={1}
+              max={allPage}
+              value={page}
+              snaps={true}
+              ticks={false}
+              onIonChange={(e) => onPageChange(e.detail.value as number)}
+              style={{ flex: 1 }}
+              dir={direction}
+            />
+          </div>
+        </IonToolbar>
+      )}
+    </>
+  )
+}

--- a/src/components/Read/Vertical.tsx
+++ b/src/components/Read/Vertical.tsx
@@ -1,17 +1,21 @@
-import { useContext, useEffect, useState } from "react"
+import { useContext, useEffect, useRef, useState } from "react"
 import { DetailContext } from "../../pages/Detail/Context"
 import { useSwipeable } from "react-swipeable"
-import { IonPage, IonRange } from "@ionic/react"
 import { useTranslation } from "react-i18next"
 import HtmlContent from "./HtmlContent"
+import { SettingsContext } from "../../SettingsContext"
+import ReadingToolbars from "./ReadingToolbars"
+import { useViewerContext } from "../../contexts/ViewerContext"
 
 export default function Vertical() {
   const article = useContext<any>(DetailContext)
+  const settings = useContext(SettingsContext)
   const {t} = useTranslation()
   const [somethingInDivClicked,setSomethingInDivClicked] = useState(false)
   const [controlShow, setControlShow] = useState(false)
   const [allPage,setAllPage] = useState(1)
   const [page,setPage] = useState(1)
+  const { fontSize, saveFontSize } = useViewerContext()
   const updateAllPage = () => {
     const container = document.getElementById("vertical_readin");
     if (!container) return;
@@ -90,11 +94,24 @@ export default function Vertical() {
     updateAllPage()
     setPage(1)
   },[article.html])
+  
+
   return (
     <div style={{paddingTop: "var(--ion-safe-area-top, 0)", paddingBottom: "var(--ion-safe-area-bottom, 0)", width: "100%", height: "100%"}}>
-      <div style={{position:"fixed",left: article.columnGap + "px"}}>
-        <span>{page} / {allPage}</span>
-      </div>
+      <ReadingToolbars
+        controlShow={controlShow}
+        fontSize={fontSize}
+        page={page}
+        allPage={allPage}
+        triggerId="font-settings-trigger-vertical"
+        onFontSizeChange={saveFontSize}
+        onPageChange={(newPage) => {
+          setPage(newPage);
+          turnToPage(newPage);
+        }}
+        direction="rtl"
+      />
+      
       <div id="vertical_container" style={{width: "100%", height: "100%", display: "flex", flexDirection: "column"}} {...handlers} onClick={(e) => handleDivClicked(e)}>
           <div id="vertical_readout" style={{position:"relative",overflow: "hidden", flex: 1, width: "100%"}}>
             <div id="vertical_readin" style={{
@@ -115,21 +132,10 @@ export default function Vertical() {
               breakInside: "avoid",
               breakAfter: "column"
             }} >
-              <HtmlContent type="vertical" setSomethingInDivClicked={setSomethingInDivClicked} />
+              <HtmlContent type="vertical" setSomethingInDivClicked={setSomethingInDivClicked} fontSize={fontSize} />
             </div>
           </div>
       </div>
-      {
-        false ?
-      <div style={{position:"fixed", bottom: "0px", width:"100%", minHeight: "150px", backgroundColor: "var(--background)", borderTop: "1px solid var(--ion-color-light-contrast)"}}>
-        <div style={{padding: "15px"}}>
-          <IonRange labelPlacement="start" ticks={true} snaps={true} min={0} max={3} onIonChange={({ detail }) => console.log(detail.value)}>
-            <div slot="label">{t("pages.detail.control.spaceBetweenPages")}</div>
-          </IonRange>
-        </div>
-      </div>
-        : <></>
-      }
     </div>
   )
 }

--- a/src/contexts/ViewerContext.tsx
+++ b/src/contexts/ViewerContext.tsx
@@ -1,0 +1,71 @@
+import { createContext, useContext, useState, useEffect, ReactNode } from "react"
+import { Preferences } from "@capacitor/preferences"
+import key from "../lib/storage.json"
+import { SettingsContext } from "../SettingsContext"
+import { DetailContext } from "../pages/Detail/Context"
+import { useLocation } from "react-router"
+
+interface ViewerContextType {
+  fontSize: number
+  saveFontSize: (newSize: number) => Promise<void>
+  loadFontSize: () => Promise<void>
+}
+
+const ViewerContext = createContext<ViewerContextType | undefined>(undefined)
+
+interface ViewerProviderProps {
+  children: ReactNode
+}
+
+export function ViewerProvider({ children }: ViewerProviderProps) {
+  const globalSettings = useContext(SettingsContext)
+  const article = useContext<any>(DetailContext)
+  const [fontSize, setFontSize] = useState<number>(24)
+  const location = useLocation();
+
+  useEffect(() => {
+    if (article.id) {
+      loadFontSize()
+    }
+  }, [location.key, article.id])
+
+
+  const loadFontSize = async () => {
+    const viewerData = await Preferences.get({ key: key.viewer })
+    if (viewerData.value) {
+      const viewerSettings = JSON.parse(viewerData.value)
+      if (viewerSettings[article.id] && viewerSettings[article.id].fontSize) {
+        setFontSize(viewerSettings[article.id].fontSize)
+      } else {
+        setFontSize(globalSettings.defaultFontSize || 24)
+      }
+    } else {
+      setFontSize(globalSettings.defaultFontSize || 24)
+    }
+  }
+
+  const saveFontSize = async (newSize: number) => {
+    const viewerData = await Preferences.get({ key: key.viewer })
+    let viewerSettings = viewerData.value ? JSON.parse(viewerData.value) : {}
+    viewerSettings[article.id] = { fontSize: newSize }
+    await Preferences.set({
+      key: key.viewer,
+      value: JSON.stringify(viewerSettings),
+    })
+    setFontSize(newSize)
+  }
+
+  return (
+    <ViewerContext.Provider value={{ fontSize, saveFontSize, loadFontSize }}>
+      {children}
+    </ViewerContext.Provider>
+  )
+}
+
+export function useViewerContext() {
+  const context = useContext(ViewerContext)
+  if (context === undefined) {
+    throw new Error("useViewerContext must be used within a ViewerProvider")
+  }
+  return context
+}

--- a/src/i18n/data/en.json
+++ b/src/i18n/data/en.json
@@ -92,6 +92,10 @@
       },
       "control": {
         "spaceBetweenPages": "Space between pages"
+      },
+      "toolbar": {
+        "fontSize": "Font Size",
+        "page": "Page"
       }
     },
     "read": {
@@ -131,6 +135,14 @@
       },
       "data": {
         "label": "Data"
+      },
+      "font": {
+        "label": "Font",
+        "title": "Font Settings",
+        "defaultFontSize": {
+          "label": "Default Font Size",
+          "description": "Set the default font size for reading articles."
+        }
       }
     }
   }

--- a/src/i18n/data/it.json
+++ b/src/i18n/data/it.json
@@ -92,6 +92,10 @@
       },
       "control": {
         "spaceBetweenPages": "Spazio tra le pagine"
+      },
+      "toolbar": {
+        "fontSize": "Dimensione carattere",
+        "page": "Pagina"
       }
     },
     "read": {
@@ -131,6 +135,14 @@
       },
       "data": {
         "label": "Dati"
+      },
+      "font": {
+        "label": "Carattere",
+        "title": "Impostazioni carattere",
+        "defaultFontSize": {
+          "label": "Dimensione carattere predefinita",
+          "description": "Imposta la dimensione del carattere predefinita per la lettura degli articoli."
+        }
       }
     }
   }

--- a/src/i18n/data/zh-TW.json
+++ b/src/i18n/data/zh-TW.json
@@ -92,6 +92,10 @@
       },
       "control": {
         "spaceBetweenPages": "頁面間距"
+      },
+      "toolbar": {
+        "fontSize": "字體大小",
+        "page": "頁面"
       }
     },
     "read": {
@@ -131,6 +135,14 @@
       },
       "data": {
         "label": "資料"
+      },
+      "font": {
+        "label": "字體",
+        "title": "字體設定",
+        "defaultFontSize": {
+          "label": "預設字體大小",
+          "description": "設定閱讀文章時的預設字體大小。"
+        }
       }
     }
   }

--- a/src/imode.css
+++ b/src/imode.css
@@ -1,5 +1,6 @@
 .nodrop {
   --ion-backdrop-color: transparent;
+  --box-shadow: none;
 }
 .nodrop .alert-wrapper,
 .nodrop .alert-wrapper.sc-ion-alert-md{
@@ -8,4 +9,11 @@
   border-width: 1px;
   box-shadow: none;
   -webkit-box-shadow: none;
+}
+
+.nodrop .ion-delegate-host{
+  border-radius: 5px;
+  border-color: var(--ion-color-light-contrast);
+  border-style: solid;
+  border-width: 1px;
 }

--- a/src/lib/defaultSettings.json
+++ b/src/lib/defaultSettings.json
@@ -4,5 +4,6 @@
   "devMode": false,
   "defaultReadView": "normal",
   "hideStatusBar": false,
-  "theme": "system"
+  "theme": "system",
+  "defaultFontSize": 24
 }

--- a/src/lib/storage.json
+++ b/src/lib/storage.json
@@ -1,4 +1,5 @@
 {
   "read": "read",
-  "settings": "settings"
+  "settings": "settings",
+  "viewer": "viewer"
 }

--- a/src/pages/Detail/Pages.tsx
+++ b/src/pages/Detail/Pages.tsx
@@ -10,6 +10,7 @@ import CleanPage from "../Layout/CleanPage"
 import Horizontal from "../../components/Read/Horizontal"
 import Normal from "../../components/Read/Normal"
 import Vertical from "../../components/Read/Vertical"
+import { ViewerProvider } from "../../contexts/ViewerContext"
 import "./Detail.css"
 
 export default function Pages() {
@@ -70,9 +71,11 @@ export default function Pages() {
   return (
     <CleanPage back={params.view === "normal"} title={articleData.title}>
       <DetailContext.Provider value={articleData}>
-        {params.view === "normal" ? <Normal /> : <></>}
-        {params.view === "horizontal" ? <Horizontal /> : <></>}
-        {params.view === "vertical" ? <Vertical /> : <></>}
+        <ViewerProvider>
+          {params.view === "normal" ? <Normal /> : null}
+          {params.view === "horizontal" ? <Horizontal /> : null}
+          {params.view === "vertical" ? <Vertical /> : null}
+        </ViewerProvider>
       </DetailContext.Provider>
     </CleanPage>
   )

--- a/src/pages/Settings/Font.tsx
+++ b/src/pages/Settings/Font.tsx
@@ -1,0 +1,44 @@
+import { useTranslation } from "react-i18next";
+import Childpage from "../Layout/ChildPage";
+import { IonItem, IonLabel, IonRange } from "@ionic/react";
+import { useContext } from "react";
+import { SettingsContext } from "../../SettingsContext";
+import { Preferences } from "@capacitor/preferences";
+import key from "../../lib/storage.json"
+import { trigger } from "../../lib/Event";
+
+export default function Font() {
+  const {t} = useTranslation()
+  const context = useContext(SettingsContext)
+  
+  const changeSetting = async (settingKey: string, settingValue: any) => {
+    let newSettings = {...context}
+    newSettings[settingKey] = settingValue
+    await Preferences.set({
+      key: key.settings,
+      value: JSON.stringify(newSettings)
+    })
+    trigger("weread:settingsChange")
+  }
+
+  return (
+    <Childpage title={t("pages.settings.font.title")}>
+      <IonItem>
+        <div style={{width: "100%"}}>
+          <IonLabel>{t("pages.settings.font.defaultFontSize.label")}</IonLabel>
+          <IonRange 
+            min={12}
+            max={48}
+            value={context.defaultFontSize || 24}
+            pin={true}
+            onIonChange={(e) => changeSetting("defaultFontSize", e.detail.value as number)}
+          >
+            <div slot="start">12</div>
+            <div slot="end">48</div>
+          </IonRange>
+          <small>{t("pages.settings.font.defaultFontSize.description")}</small>
+        </div>
+      </IonItem>
+    </Childpage>
+  )
+}

--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -191,6 +191,13 @@ export default function Settings() {
       </IonItem>
     )
   }
+  const FontPage = () => {
+    return (
+      <IonItem detail={true} onClick={() => history.push("/font")}>
+        <IonLabel>{t("pages.settings.font.label")}</IonLabel>
+      </IonItem>
+    )
+  }
 
   useEffect(() => {
     const getDeviceInfo = async () => {
@@ -209,6 +216,7 @@ export default function Settings() {
         <IModeToggle /> : null}
         {/* <StatusBarToggle /> */}
         <ChangeLang />
+        <FontPage />
         <DataPage />
         <DevModeToggle />
         <InfoPage />


### PR DESCRIPTION
- Add Font component and /font route to let users configure font preferences.
- Introduce a new “viewer” preference key to store per‑article viewer state (e.g., font size).
- Update DeleteAllData, DeleteArticle, ExportData, and ImportData to include/remove viewer settings.
- Enhance the Vertical reader with ViewerContext, ReadingToolbars, and import i‑mode CSS for styling.